### PR TITLE
Allow customizing the span name

### DIFF
--- a/lib/opencensus_tesla.ex
+++ b/lib/opencensus_tesla.ex
@@ -22,13 +22,16 @@ defmodule OpencensusTesla.Middleware do
   Following Middleware options are accepted:
     - `span_name_override` - if provided, will be used as the
       span name. Otherwise request path is used by default.
+      A function taking the request path as argument and
+      returning a string to use as span name is expected.
   """
 
   import Opencensus.Trace
 
   def call(env, next, options) do
     uri = %URI{path: path} = URI.parse(env.url)
-    span_name = Keyword.get(options, :span_name_override, path)
+    span_name_function = Keyword.get(options, :span_name_override)
+    span_name = if span_name_function, do: span_name_function.(path), else: path
 
     with_child_span(span_name, http_attributes(env, uri)) do
       span_ctx = :ocp.current_span_ctx()

--- a/lib/opencensus_tesla.ex
+++ b/lib/opencensus_tesla.ex
@@ -16,14 +16,21 @@ defmodule OpencensusTesla.Middleware do
     plug OpencensusTesla.Middleware
   end
   ```
+
+  ### Options
+
+  Following Middleware options are accepted:
+    - `span_name_override` - if provided, will be used as the
+      span name. Otherwise request path is used by default.
   """
 
   import Opencensus.Trace
 
-  def call(env, next, _options) do
+  def call(env, next, options) do
     uri = %URI{path: path} = URI.parse(env.url)
+    span_name = Keyword.get(options, :span_name_override, path)
 
-    with_child_span(path, http_attributes(env, uri)) do
+    with_child_span(span_name, http_attributes(env, uri)) do
       span_ctx = :ocp.current_span_ctx()
       headers = :oc_propagation_http_tracecontext.to_headers(span_ctx)
 

--- a/test/opencensus_tesla_test.exs
+++ b/test/opencensus_tesla_test.exs
@@ -14,10 +14,26 @@ defmodule TestRequestClient do
   end)
 end
 
+defmodule TestRequestClientCustomized do
+  use Tesla
+
+  plug(OpencensusTesla.Middleware, span_name_override: fn path -> path <> "test" end)
+
+  adapter(fn env ->
+    {status, headers, body} =
+      case env.url do
+        _ ->
+          {200, [], ""}
+      end
+
+    {:ok, %{env | status: status, headers: headers, body: body}}
+  end)
+end
+
 defmodule OpencensusTeslaTest do
   use ExUnit.Case
 
-  test "span is reported after request is complete" do
+  setup do
     Application.load(:opencensus)
     Application.put_env(:opencensus, :send_interval_ms, 1)
     Application.put_env(:opencensus, :reporters, [{:oc_reporter_pid, self()}])
@@ -25,9 +41,21 @@ defmodule OpencensusTeslaTest do
     {:ok, _} = Application.ensure_all_started(:opencensus)
     {:ok, _} = Application.ensure_all_started(:opencensus_elixir)
 
+    on_exit(fn -> Application.stop(:opencensus) end)
+    :ok
+  end
+
+  test "span is reported after request is complete" do
     {:ok, env} = TestRequestClient.post("/", "")
     assert 200 = env.status
 
-    assert_receive {:span, _}, 1_000
+    assert_receive {:span, {:span, "/", _, _, _, _, _, _, _, _, _, _, _, _, _, _, _}}, 1_000
+  end
+
+  test "can override span name" do
+    {:ok, env} = TestRequestClientCustomized.post("/", "")
+    assert 200 = env.status
+
+    assert_receive {:span, {:span, "/test", _, _, _, _, _, _, _, _, _, _, _, _, _, _, _}}, 1_000
   end
 end


### PR DESCRIPTION
Hello, thank you for sharing the library.

I'm proposing a slight addition, whereby the middleware client can override the span name to a fixed struct, instead of the request path, which remains the default.

This is useful, when requests being made have IDs in the paths, and those end up in span names. E.g. Jaeger will interpret this as the `operation`, which can be filtered on, but it is rendered useless if there's an `operation` per every ID.